### PR TITLE
Add activity feed api

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

This PR introduces a new server script for the Graphite demo application.

### What changed?

A new server.js file has been added to the Graphite demo. This file implements an Express server and defines a '/feed' endpoint that returns a fake activity feed.

### How to test?

To test this change, start the server by running server.js and send a GET request to localhost:3000/feed. The response should be the activity feed JSON.

### Why make this change?

The addition of a server script allows us to simulate real server-side functionality in our demo application, providing a more realistic user experience during demonstrations.

---

